### PR TITLE
Fix the Apply Method on Changeset to Make the Apply Method Can Set Nil Value

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -87,7 +87,7 @@ func (c *Changeset) Apply(doc *rel.Document, mut *rel.Mutation) {
 				c.applyAssocMany(doc, field, mut, v)
 			}
 		default:
-			if field != pField && v != nil && scannable(c.types[field]) {
+			if field != pField && scannable(c.types[field]) {
 				c.set(doc, mut, field, v)
 			}
 		}

--- a/changeset_test.go
+++ b/changeset_test.go
@@ -19,6 +19,7 @@ type User struct {
 	Address      Address
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+	DeletedAt    *time.Time
 }
 
 type Transaction struct {
@@ -123,6 +124,7 @@ func TestChangesetApply(t *testing.T) {
 			rel.Set("age", 20),
 			rel.Set("created_at", now),
 			rel.Set("updated_at", now),
+			rel.Set("deleted_at", nil),
 		)
 		transaction1Mutation = rel.Apply(rel.NewDocument(&Transaction{}),
 			rel.Set("item", "Sword"),
@@ -148,6 +150,8 @@ func TestChangesetApply(t *testing.T) {
 		ch := Cast(data, input, []string{"street", "notes", "flagged"})
 		return ch
 	})
+
+	PutChange(ch, "deleted_at", nil)
 
 	userMutation.SetAssoc("transactions", transaction1Mutation, transaction2Mutation)
 	userMutation.SetAssoc("address", addressMutation)


### PR DESCRIPTION
This PR to fix the `Apply` method on `Changeset`, so `rel` will be able to update the column with `nil` value which is from the `Changes`.