### PR TITLE
Added support for non-serial pField mutation

### DIFF
--- a/change.go
+++ b/change.go
@@ -8,6 +8,7 @@ func Change(schema interface{}, changes ...map[string]interface{}) *Changeset {
 
 	if len(changes) > 0 {
 		ch.changes = changes[0]
+		ch.ignorePrimary = true
 	} else {
 		ch.changes = make(map[string]interface{})
 	}

--- a/change.go
+++ b/change.go
@@ -8,7 +8,6 @@ func Change(schema interface{}, changes ...map[string]interface{}) *Changeset {
 
 	if len(changes) > 0 {
 		ch.changes = changes[0]
-		ch.ignorePrimary = true
 	} else {
 		ch.changes = make(map[string]interface{})
 	}

--- a/changeset.go
+++ b/changeset.go
@@ -72,9 +72,19 @@ func (c Changeset) Constraints() Constraints {
 // Apply mutation.
 func (c *Changeset) Apply(doc *rel.Document, mut *rel.Mutation) {
 	var (
-		pField = doc.PrimaryField()
-		now    = time.Now().Truncate(time.Second)
+		pField        = doc.PrimaryField()
+		mutablePField = false
+		now           = time.Now().Truncate(time.Second)
 	)
+
+	switch c.values[pField].(type) {
+	case int:
+		break
+	default:
+		if c.changes[pField] != nil {
+			mutablePField = true
+		}
+	}
 
 	for field, value := range c.changes {
 		switch v := value.(type) {
@@ -87,7 +97,7 @@ func (c *Changeset) Apply(doc *rel.Document, mut *rel.Mutation) {
 				c.applyAssocMany(doc, field, mut, v)
 			}
 		default:
-			if field != pField && scannable(c.types[field]) {
+			if (mutablePField || field != pField) && scannable(c.types[field]) {
 				c.set(doc, mut, field, v)
 			}
 		}

--- a/changeset.go
+++ b/changeset.go
@@ -79,7 +79,6 @@ func (c *Changeset) Apply(doc *rel.Document, mut *rel.Mutation) {
 
 	switch c.values[pField].(type) {
 	case int:
-		break
 	default:
 		if c.changes[pField] != nil {
 			mutablePField = true

--- a/changeset.go
+++ b/changeset.go
@@ -88,7 +88,7 @@ func (c *Changeset) Apply(doc *rel.Document, mut *rel.Mutation) {
 				c.applyAssocMany(doc, field, mut, v)
 			}
 		default:
-			if (pField != field || pField == field && !c.ignorePrimary) && scannable(c.types[field]) { //if not PK - try to set
+			if (pField != field || pField == field && !c.ignorePrimary) && scannable(c.types[field]) {
 				c.set(doc, mut, field, v)
 			}
 		}

--- a/changeset_test.go
+++ b/changeset_test.go
@@ -287,3 +287,36 @@ func TestChangesetApply_MutablePK_FromConvert(t *testing.T) {
 		UpdatedAt: now,
 	}, user)
 }
+
+func TestChangesetApply_MutablePK_FromChange(t *testing.T) {
+	var (
+		user  UUIDUser
+		now   = time.Now().Truncate(time.Second)
+		doc   = rel.NewDocument(&user)
+		input = map[string]interface{}{
+			"uuid": "3a90fc96-6cff-4914-9ce8-01c9e607b28b",
+			"name": "Luffy",
+			"age":  20,
+		}
+		userMutation = rel.Apply(rel.NewDocument(&UUIDUser{}),
+			rel.Set("name", "Luffy"),
+			rel.Set("age", 20),
+			rel.Set("created_at", now),
+			rel.Set("updated_at", now),
+		)
+	)
+
+	ch := Change(user, input)
+	UniqueConstraint(ch, "name")
+	mut := rel.Apply(doc, ch)
+
+	assert.Nil(t, ch.Error())
+	assert.Equal(t, userMutation.Mutates, mut.Mutates)
+	assert.NotNil(t, mut.ErrorFunc)
+	assert.Equal(t, UUIDUser{
+		Name:      "Luffy",
+		Age:       20,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, user)
+}

--- a/changeset_test.go
+++ b/changeset_test.go
@@ -299,6 +299,7 @@ func TestChangesetApply_MutablePK_FromChange(t *testing.T) {
 			"age":  20,
 		}
 		userMutation = rel.Apply(rel.NewDocument(&UUIDUser{}),
+			rel.Set("uuid", "3a90fc96-6cff-4914-9ce8-01c9e607b28b"),
 			rel.Set("name", "Luffy"),
 			rel.Set("age", 20),
 			rel.Set("created_at", now),
@@ -314,6 +315,7 @@ func TestChangesetApply_MutablePK_FromChange(t *testing.T) {
 	assert.Equal(t, userMutation.Mutates, mut.Mutates)
 	assert.NotNil(t, mut.ErrorFunc)
 	assert.Equal(t, UUIDUser{
+		UUID:      "3a90fc96-6cff-4914-9ce8-01c9e607b28b",
 		Name:      "Luffy",
 		Age:       20,
 		CreatedAt: now,

--- a/changeset_test.go
+++ b/changeset_test.go
@@ -216,7 +216,8 @@ func TestChangesetApply_constraint(t *testing.T) {
 	}, user)
 }
 
-func TestChangesetApply_MutablePK(t *testing.T) {
+//If PK is explicitly caseted then it should be updated
+func TestChangesetApply_updatePK(t *testing.T) {
 	var (
 		user  UUIDUser
 		now   = time.Now().Truncate(time.Second)
@@ -251,7 +252,8 @@ func TestChangesetApply_MutablePK(t *testing.T) {
 	}, user)
 }
 
-func TestChangesetApply_MutablePK_FromConvert(t *testing.T) {
+//Covert function should ignore the PK updates for safety reasons
+func TestChangesetApply_updatePK_fromConvert(t *testing.T) {
 	var (
 		user  UUIDUser
 		now   = time.Now().Truncate(time.Second)
@@ -288,7 +290,8 @@ func TestChangesetApply_MutablePK_FromConvert(t *testing.T) {
 	}, user)
 }
 
-func TestChangesetApply_MutablePK_FromChange(t *testing.T) {
+//If PK is explicitly set in the Change function it should be updated
+func TestChangesetApply_updatePK_fromChange(t *testing.T) {
 	var (
 		user  UUIDUser
 		now   = time.Now().Truncate(time.Second)

--- a/changeset_test.go
+++ b/changeset_test.go
@@ -250,3 +250,40 @@ func TestChangesetApply_MutablePK(t *testing.T) {
 		UpdatedAt: now,
 	}, user)
 }
+
+func TestChangesetApply_MutablePK_FromConvert(t *testing.T) {
+	var (
+		user  UUIDUser
+		now   = time.Now().Truncate(time.Second)
+		doc   = rel.NewDocument(&user)
+		input = struct {
+			UUID string
+			Name string
+			Age  int
+		}{
+			UUID: "3a90fc96-6cff-4914-9ce8-01c9e607b28b",
+			Name: "Luffy",
+			Age:  20,
+		}
+		userMutation = rel.Apply(rel.NewDocument(&UUIDUser{}),
+			rel.Set("name", "Luffy"),
+			rel.Set("age", 20),
+			rel.Set("created_at", now),
+			rel.Set("updated_at", now),
+		)
+	)
+
+	ch := Convert(input)
+	UniqueConstraint(ch, "name")
+	mut := rel.Apply(doc, ch)
+
+	assert.Nil(t, ch.Error())
+	assert.Equal(t, userMutation.Mutates, mut.Mutates)
+	assert.NotNil(t, mut.ErrorFunc)
+	assert.Equal(t, UUIDUser{
+		Name:      "Luffy",
+		Age:       20,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}, user)
+}

--- a/convert.go
+++ b/convert.go
@@ -1,6 +1,7 @@
 package changeset
 
 // Convert a struct as changeset, every field's value will be treated as changes. Returns a new changeset.
+// PK changes in the changeset created with this function will be ignored
 func Convert(data interface{}) *Changeset {
 	ch := &Changeset{}
 	ch.values = make(map[string]interface{})

--- a/convert.go
+++ b/convert.go
@@ -5,6 +5,6 @@ func Convert(data interface{}) *Changeset {
 	ch := &Changeset{}
 	ch.values = make(map[string]interface{})
 	ch.changes, ch.types, _ = mapSchema(data, false)
-
+	ch.ignorePrimary = true // set ignore primary to prevent implicit PK change
 	return ch
 }


### PR DESCRIPTION
Yet this implementation does not protect from accidental mutation of pk, it assumes the possibility of explicit, non-serial PK mutation in the changeset. 

Probably this mutation should only occur during the insertion, however, the `Mutator` interface does not specify the action, unlike in Ecto, and I did not find a way to deduce the action from `Apply method`. 

Closes #38 